### PR TITLE
specify usage of `httr` library on slide 65

### DIFF
--- a/05-webdata/05-webdata.Rmd
+++ b/05-webdata/05-webdata.Rmd
@@ -1507,7 +1507,7 @@ for (i in 1:length(list_of_urls)) {
 ### Two easy-to-implement practices
 
 1. Get in touch with website administrators / data owners.
-2. Use HTTP header fields `From` and `User-Agent` to provide information about yourself.
+2. Use HTTP header fields `From` and `User-Agent` to provide information about yourself (by passing these to `add_headers()` from the `httr` library).
 
 ]
 


### PR DESCRIPTION
Added a line stating that the `add_header()` function belongs to the library `httr`. This signals that students have to install and import the library before copying and using the provided code. Without knowing this, the code will break on their scripts and they might not understand why (I had to google multiple times until I found out that `add_header()` belonged to a separate library that I did not have installed).

I did not provide the knitted html and pdf files to this commit because my knit is producing further line changes in other slides in the knitted document.